### PR TITLE
Add a sample Shields.IO badge for use on READMEs

### DIFF
--- a/saythanks/templates/inbox.htm.j2
+++ b/saythanks/templates/inbox.htm.j2
@@ -19,7 +19,7 @@
 
 <p>
     You may now direct your users (in a README or documentation, for example)
-    to <a href="{{ url_for('display_submit_note', inbox=user['nickname'])}}">this URL</a>, where they can submit a note of thankfullness:
+    to <a href="{{ url_for('display_submit_note', inbox=user['nickname'])}}">this URL</a>, where they can submit a note of thankfulness:
 </p>
 
 <a href="{{ url_for('display_submit_note', inbox=user['nickname'])}}">

--- a/saythanks/templates/inbox.htm.j2
+++ b/saythanks/templates/inbox.htm.j2
@@ -28,6 +28,10 @@
     </button>
 </a>
 
+<a href="{{ url_for('display_submit_note', inbox=user['nickname'])}}">
+    <img src="https://img.shields.io/badge/SayThanks.io-%E2%98%BC-1EAEDB.svg" />
+</>
+
 <hr>
 <h3>Notes of Thankfulness:</h3>
 


### PR DESCRIPTION
As implemented on [octohatrack's readme](https://github.com/LABHR/octohatrack#octohatrack)

Uses the 'skeleton blue' as the colour as per the colouration of the sun icon in on the website. 

Also: 1 x spelling correction. 