### PR TITLE
Add custom CSS formatting for header link

### DIFF
--- a/saythanks/static/css/saythanks.css
+++ b/saythanks/static/css/saythanks.css
@@ -1,0 +1,4 @@
+/* The Sun icon in the header should not have an underline */
+h1 a { 
+    text-decoration: none;
+} 

--- a/saythanks/static/index.html
+++ b/saythanks/static/index.html
@@ -21,6 +21,7 @@
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <link rel="stylesheet" href="css/normalize.css">
   <link rel="stylesheet" href="css/skeleton.css">
+  <link rel="stylesheet" href="css/saythanks.css">
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->

--- a/saythanks/templates/base.htm.j2
+++ b/saythanks/templates/base.htm.j2
@@ -20,6 +20,7 @@
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/normalize.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/skeleton.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/saythanks.css') }}">
 
      <!-- Favicon
      –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
I think it looks a little bit better if the sun icon[0] doesn't have the `text-decoration` bar at the bottom. 

Added a custom CSS file to implement, as opposed to appending to skeleton/normalise 

[0] This is, if you want to keep the text-icon `☼ U+263C WHITE SUN WITH RAYS` as opposed to `☀️ U+2600 U+FE0F BLACK SUN WITH RAYS with Emoji Variation Selector`
