### PR TITLE
remove inaccurate statement about GitHub only accounts

### DIFF
--- a/saythanks/templates/index.htm.j2
+++ b/saythanks/templates/index.htm.j2
@@ -78,9 +78,6 @@
 
     <hr>
 
-    <p>Account creation and URL generation is currently powered by GitHub. There are no plans to add additional account types at this time.</p>
-    <hr>
-
     <p>
         This is an open source project, and its code is being actively
         developed in the open <a href="https://github.com/kennethreitz/saythanks.io">on GitHub</a>.


### PR DESCRIPTION
Email based accounts were added in #13 so the statement about GitHub only is inaccurate.